### PR TITLE
Multichannel USB audio play and record

### DIFF
--- a/teensy4/AudioRate.h
+++ b/teensy4/AudioRate.h
@@ -1,0 +1,162 @@
+/* Teensyduino Core Library
+ * http://www.pjrc.com/teensy/
+ * Copyright (c) 2017 PJRC.COM, LLC.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * 1. The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * 2. If the Software is incorporated into a build system that allows
+ * selection among a list of target devices, then similar target
+ * devices manufactured by PJRC.COM must be included in the list of
+ * target devices and selectable in the same manner.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef AudioRate_h
+#define AudioRate_h
+
+#ifndef AUDIO_SAMPLE_RATE
+#define AUDIO_SAMPLE_RATE (44100)
+#endif
+
+#ifdef AUDIO_SAMPLE_RATE_EXACT
+#error You must set AUDIO_SAMPLE_RATE to an integer, not AUDIO_SAMPLE_RATE_EXACT to a float.  This is a change due to preprocess #if rate== stuff.  Probably can be worked around, but this is expedient.
+#endif
+
+#define AUDIO_SAMPLE_RATE_EXACT (AUDIO_SAMPLE_RATE * 1.0f)
+
+#ifndef USB_AUDIO_TX_CHANNELS
+#define USB_AUDIO_TX_CHANNELS (2U) /* NUMBER OF CHANNELS IN ISO_IN transactions */
+#endif
+
+#ifndef USB_AUDIO_RX_CHANNELS
+#define USB_AUDIO_RX_CHANNELS (2U) /* NUMBER OF CHANNELS IN ISO_OUT transactions */
+#endif
+
+#ifndef USB_AUDIO_BYTES_PER_SAMPLE
+#define USB_AUDIO_BYTES_PER_SAMPLE 2
+#endif
+
+// The number of RX data pins used for SAI reception.  
+// SAI1 on teensy 4 has 4 possible pins for each of TX/RX
+// They are shared, and can't be used simultaneously.
+// On Teensy They are
+
+// pin#  | TEENSY  | USE     | PAD
+//       | NAME    |         |
+//-------|---------|---------|---------- 
+//  7    | OUT1A   | TX1     | GPIO_B1_01_ALT3
+// 32    | OUT1B   | TX2 RX4 | GPIO_B0_12_ALT3
+//  9    | OUT1C   | TX3 RX3 | GPIO_B0_11_ALT3
+//  6    | OUT1D   | TX4 RX2 | GPIO_B0_10_ALT3
+//  8    | IN1     |     RX1 | GPIO_B1_00_ALT3
+#ifndef AUDIO_N_SAI1_RX_DATAPINS
+#define AUDIO_N_SAI1_RX_DATAPINS 1
+#endif
+
+#ifndef AUDIO_N_SAI1_TX_DATAPINS
+#define AUDIO_N_SAI1_TX_DATAPINS 1
+#endif
+
+# if (AUDIO_N_SAI1_RX_DATAPINS > 4  || AUDIO_N_SAI1_RX_DATAPINS < 1)
+#error SAI1 may have between 1 and 4 (inclusive) data pins for RX
+#endif
+# if (AUDIO_N_SAI1_TX_DATAPINS > 4  || AUDIO_N_SAI1_TX_DATAPINS < 1)
+#error SAI1 may have between 1 and 4 (inclusive) data pins for TX
+#endif
+
+#if (AUDIO_N_SAI1_RX_DATAPINS + AUDIO_N_SAI1_TX_DATAPINS > 5)
+#error SAI1 has only 5 data pins.  You ve asked for too many.
+#endif
+
+#define USB_AUDIO_BYTES_PER_SAMPLE 2 /* warning... don't change this... it's not easily changeable yet, */
+#define USB_AUDIO_BYTES_PER_TX_FRAME (USB_AUDIO_TX_CHANNELS*USB_AUDIO_BYTES_PER_SAMPLE)
+#define USB_AUDIO_BYTES_PER_RX_FRAME (USB_AUDIO_RX_CHANNELS*USB_AUDIO_BYTES_PER_SAMPLE)
+
+/* This isn't a parameter... yet.  Don't change it.. */
+#define TDM_CHANNELS_PER_PIN 16
+
+/*
+  AUDIO_TX_SIZE and AUDIO_RX_SIZE are the maximum TX and RX sizes
+  respectively, IN BYTES.  
+   
+  for 44.1khz, 16-bits, the number of bytes per 1ms usb frame is
+     44100 af     sec        2 channels    2 bytes      176.4 bytes
+   ----------- * -------- * ---------- * ------------ = -----------
+      sec         1000 uf     audio_frame    sample      uf
+
+  where:
+     af     : audio_frame (i.e. what you typically call a sample)
+     sample : an actual, single sample representing one channel, at one time
+     uf     : usb frame.  1khz for full speed
+     channel: channel is made up of 1 sample for every channel in the stream
+
+  for 44.1khz, you must transmit an average of 176.4 bytes, which is
+  44.1 audio_frame per usb_frame, so sometimes you need to transmit 44
+  and somteims you need to transmit 45. So buffer sizes need to be 
+
+  45 * 2 channels * 2 bytes = 180 bytes.
+  
+  For 48000, it's exactly 48000/1000 = 48 audio_frames/usb_frame.
+  Unfortunately, the USB 1khz rate isn't exactly the same as the
+  audio's 1khz rate, so you might sometimes need to transmit one extra
+  'makeup' frame sometimes, depening on the synchronization method.
+  
+  In which case it would be
+  (48+1) audio_frames * 2 channels * 2 bytes = 192 bytes
+*/
+
+#if AUDIO_SAMPLE_RATE == 44100
+  #define AUDIO_BASEFRAMES (44)
+// Send an extra frame every 10 usb frames */
+  #define AUDIO_BASEFRAMES_EXTRA (10)
+#elif AUDIO_SAMPLE_RATE == 48000
+#define AUDIO_BASEFRAMES (48)
+#elif AUDIO_SAMPLE_RATE == 32000
+  #define AUDIO_BASEFRAMES (32)
+#elif AUDIO_SAMPLE_RATE == 16000
+  #define AUDIO_BASEFRAMES (16)
+#elif AUDIO_SAMPLE_RATE ==  8000
+  #define AUDIO_BASEFRAMES (8)
+#else
+#error UNSUPPORTED SAMPLE RATE, or you have specified a FLOAT.  Currently supported rates are 44100, 48000, 32000, 16000, 8000.   Set AUDIO_SAMPLE_RATE=<one of the above>
+#endif
+
+#ifndef AUDIO_BASEFRAMES_EXTRA
+// the even multiples of 1kHz don't need any extra frames typically.
+#define AUDIO_BASEFRAMES_EXTRA 0
+#endif
+
+// We still need a +1 to BASEFRAMES because we still need the ability to transmit
+// one extra frame when the USB host is consuming frames too quickly.
+#define AUDIO_TX_SIZE         ((AUDIO_BASEFRAMES+1) * USB_AUDIO_TX_CHANNELS * USB_AUDIO_BYTES_PER_SAMPLE)
+#define AUDIO_RX_SIZE         ((AUDIO_BASEFRAMES+1) * USB_AUDIO_RX_CHANNELS * USB_AUDIO_BYTES_PER_SAMPLE)
+
+#ifndef AUDIO_N_SAI1_RX_DATAPINS
+#    define AUDIO_N_SAI1_RX_DATAPINS (1)
+#endif
+
+#ifndef AUDIO_N_SAI1_TX_DATAPINS
+#    define AUDIO_N_SAI1_TX_DATAPINS (1)
+#endif
+
+#ifndef TDM_CHANNELS_PER_PIN
+#define TDM_CHANNELS_PER_PIN (16)
+#endif
+
+#endif

--- a/teensy4/AudioStream.h
+++ b/teensy4/AudioStream.h
@@ -54,11 +54,7 @@
 #define AUDIO_BLOCK_SAMPLES  128
 #endif
 
-#ifndef AUDIO_SAMPLE_RATE_EXACT
-#define AUDIO_SAMPLE_RATE_EXACT 44100.0f
-#endif
-
-#define AUDIO_SAMPLE_RATE AUDIO_SAMPLE_RATE_EXACT
+#include "AudioRate.h"
 
 #define noAUDIO_DEBUG_CLASS // disable this class by default
 

--- a/teensy4/imxrt.h
+++ b/teensy4/imxrt.h
@@ -8395,6 +8395,11 @@ typedef struct {
 #define I2S_RCR4_SYWD(n)		((uint32_t)((n) & 0x1f)<<8)	// Sync Width
 #define I2S_RCR4_FRSZ(n)		((uint32_t)((n) & 0x0f)<<16)	// Frame Size
 #define I2S_RCR4_FCONT			((uint32_t)1<<28)	// FIFO Continue on Error
+#define I2S_RCR4_FCOMB(n)               ((uint32_t)(n & 0x3)<<26)	// FIFO Combine Mode
+#define I2S_RCR4_FCOMB_DISABLED          I2S_RCR4_FCOMB(0) // No FIFO combining
+#define I2S_RCR4_FCOMB_ENABLED_ON_WRITES I2S_RCR4_FCOMB(1) // <-- this is the one you want.
+#define I2S_RCR4_FCOMB_ENABLED_ON_READS  I2S_RCR4_FCOMB(2) 
+#define I2S_RCR4_FCOMB_ENABLED_ON_RW     I2S_RCR4_FCOMB(3)
 #define I2S_RCR5_FBT(n)			((uint32_t)((n) & 0x1f)<<8)	// First Bit Shifted
 #define I2S_RCR5_W0W(n)			((uint32_t)((n) & 0x1f)<<16)	// Word 0 Width
 #define I2S_RCR5_WNW(n)			((uint32_t)((n) & 0x1f)<<24)	// Word N Width
@@ -8419,6 +8424,11 @@ typedef struct {
 #define I2S_TCR4_SYWD(n)		((uint32_t)((n) & 0x1f)<<8)	// Sync Width
 #define I2S_TCR4_FRSZ(n)		((uint32_t)((n) & 0x0f)<<16)	// Frame Size
 #define I2S_TCR4_FCONT			((uint32_t)1<<28)	// FIFO Continue on Error
+#define I2S_TCR4_FCOMB(n)               ((uint32_t)(n & 0x3)<<26)	// FIFO Combine Mode
+#define I2S_TCR4_FCOMB_DISABLED          I2S_TCR4_FCOMB(0)
+#define I2S_TCR4_FCOMB_ENABLED_ON_READS  I2S_TCR4_FCOMB(1) // <--- this is the one you want
+#define I2S_TCR4_FCOMB_ENABLED_ON_WRITES I2S_TCR4_FCOMB(2)
+#define I2S_TCR4_FCOMB_ENABLED_ON_RW     I2S_TCR4_FCOMB(3)
 #define I2S_TCR5_FBT(n)			((uint32_t)((n) & 0x1f)<<8) 	// First Bit Shifted
 #define I2S_TCR5_W0W(n)			((uint32_t)((n) & 0x1f)<<16)	// Word 0 Width
 #define I2S_TCR5_WNW(n)			((uint32_t)((n) & 0x1f)<<24)	// Word N Width

--- a/teensy4/usb_audio.h
+++ b/teensy4/usb_audio.h
@@ -78,29 +78,28 @@ public:
 	}
 private:
 	static bool update_responsibility;
-	static audio_block_t *incoming_left;
-	static audio_block_t *incoming_right;
-	static audio_block_t *ready_left;
-	static audio_block_t *ready_right;
+	static audio_block_t *incoming[USB_AUDIO_RX_CHANNELS];
+	static audio_block_t *ready[USB_AUDIO_RX_CHANNELS];
 	static uint16_t incoming_count;
 	static uint8_t receive_flag;
+	static int all_ready(void);
 };
 
 class AudioOutputUSB : public AudioStream
 {
 public:
-	AudioOutputUSB(void) : AudioStream(2, inputQueueArray) { begin(); }
+	AudioOutputUSB(void) : AudioStream(USB_AUDIO_TX_CHANNELS, inputQueueArray) { begin(); }
 	virtual void update(void);
 	void begin(void);
 	friend unsigned int usb_audio_transmit_callback(void);
 private:
 	static bool update_responsibility;
-	static audio_block_t *left_1st;
-	static audio_block_t *left_2nd;
-	static audio_block_t *right_1st;
-	static audio_block_t *right_2nd;
+	static audio_block_t *chan_1st[USB_AUDIO_TX_CHANNELS];
+	static audio_block_t *chan_2nd[USB_AUDIO_TX_CHANNELS];
 	static uint16_t offset_1st;
-	audio_block_t *inputQueueArray[2];
+	audio_block_t *inputQueueArray[USB_AUDIO_TX_CHANNELS];
+        static int allocate_tx_blocks(audio_block_t *blocks[USB_AUDIO_TX_CHANNELS]);
+
 };
 #endif // __cplusplus
 

--- a/teensy4/usb_desc.c
+++ b/teensy4/usb_desc.c
@@ -71,6 +71,17 @@
 
 #define LSB(n) ((n) & 255)
 #define MSB(n) (((n) >> 8) & 255)
+#define MMSB(n) (((n) >> 16) & 255)
+#define TSAMFREQ LSB(AUDIO_SAMPLE_RATE), MSB(AUDIO_SAMPLE_RATE), MMSB(AUDIO_SAMPLE_RATE)
+
+// This defines the channel config, which is basically a
+// '1' in every bit, filling from the LSbit for each channel.
+// when the number of channels is > 16, just fill the
+// wChannelCoinfig with all 1s.
+#define WCHANNELCONFIG(N_CHANNELS)                      \
+    (uint8_t) ((N_CHANNELS<16) ? LSB((1ULL<<N_CHANNELS)-1) : 0xff), \
+    (uint8_t) ((N_CHANNELS<16) ? MSB((1ULL<<N_CHANNELS)-1) : 0xff)
+
 
 #ifdef CDC_IAD_DESCRIPTOR
 #ifndef DEVICE_CLASS
@@ -1444,8 +1455,8 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	//0x03, 0x06,				// wTerminalType, 0x0603 = Line Connector
 	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
+	USB_AUDIO_TX_CHANNELS,			// bNrChannels
+	WCHANNELCONFIG(USB_AUDIO_TX_CHANNELS),	// wChannelConfig, 0x0003 = Left & Right Front.
 	0,					// iChannelNames
 	0, 					// iTerminal
 	// Output Terminal Descriptor
@@ -1466,8 +1477,8 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	3,					// bTerminalID
 	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
+	USB_AUDIO_RX_CHANNELS,			// bNrChannels
+	WCHANNELCONFIG(USB_AUDIO_RX_CHANNELS),	// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
 	// Volume feature descriptor
@@ -1528,11 +1539,11 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
+	USB_AUDIO_TX_CHANNELS,			// bNrChannels = 2
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+        TSAMFREQ,                               // tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -1587,11 +1598,11 @@ PROGMEM const uint8_t usb_config_descriptor_480[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
+	USB_AUDIO_RX_CHANNELS,			// bNrChannels = 2
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+        TSAMFREQ,                               // tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -2458,8 +2469,8 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	//0x03, 0x06,				// wTerminalType, 0x0603 = Line Connector
 	0x02, 0x06,				// wTerminalType, 0x0602 = Digital Audio
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
+	USB_AUDIO_TX_CHANNELS,			// bNrChannels
+	WCHANNELCONFIG(USB_AUDIO_TX_CHANNELS),	// wChannelConfig, 0x0003 = Left & Right Front.
 	0,					// iChannelNames
 	0, 					// iTerminal
 	// Output Terminal Descriptor
@@ -2480,8 +2491,8 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	3,					// bTerminalID
 	0x01, 0x01,				// wTerminalType, 0x0101 = USB_STREAMING
 	0,					// bAssocTerminal, 0 = unidirectional
-	2,					// bNrChannels
-	0x03, 0x00,				// wChannelConfig, 0x0003 = Left & Right Front
+	USB_AUDIO_RX_CHANNELS,			// bNrChannels
+	WCHANNELCONFIG(USB_AUDIO_RX_CHANNELS),	// wChannelConfig, 0x0003 = Left & Right Front
 	0,					// iChannelNames
 	0, 					// iTerminal
 	// Volume feature descriptor
@@ -2542,11 +2553,11 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
+	USB_AUDIO_TX_CHANNELS,			// bNrChannels = 2
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+        TSAMFREQ,                               // tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength
@@ -2601,11 +2612,11 @@ PROGMEM const uint8_t usb_config_descriptor_12[CONFIG_DESC_SIZE] = {
 	0x24,					// bDescriptorType = CS_INTERFACE
 	2,					// bDescriptorSubtype = FORMAT_TYPE
 	1,					// bFormatType = FORMAT_TYPE_I
-	2,					// bNrChannels = 2
+	USB_AUDIO_RX_CHANNELS,			// bNrChannels = 2
 	2,					// bSubFrameSize = 2 byte
 	16,					// bBitResolution = 16 bits
 	1,					// bSamFreqType = 1 frequency
-	LSB(44100), MSB(44100), 0,		// tSamFreq
+        TSAMFREQ,                               // tSamFreq
 	// Standard AS Isochronous Audio Data Endpoint Descriptor
 	// USB DCD for Audio Devices 1.0, Section 4.6.1.1, Table 4-20, page 61-62
 	9, 					// bLength

--- a/teensy4/usb_desc.h
+++ b/teensy4/usb_desc.h
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include "AudioRate.h"
 
 #define ENDPOINT_TRANSMIT_UNUSED	0x00020000
 #define ENDPOINT_TRANSMIT_ISOCHRONOUS	0x00C40000
@@ -762,9 +763,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define SEREMU_RX_INTERVAL    2
   #define AUDIO_INTERFACE	1	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     3
-  #define AUDIO_TX_SIZE         180
   #define AUDIO_RX_ENDPOINT     3
-  #define AUDIO_RX_SIZE         180
   #define AUDIO_SYNC_ENDPOINT	4
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_INTERRUPT + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_ISOCHRONOUS + ENDPOINT_TRANSMIT_ISOCHRONOUS
@@ -801,9 +800,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MIDI_RX_SIZE_480      512
   #define AUDIO_INTERFACE	3	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     5
-  #define AUDIO_TX_SIZE         180
   #define AUDIO_RX_ENDPOINT     5
-  #define AUDIO_RX_SIZE         180
   #define AUDIO_SYNC_ENDPOINT	6
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
@@ -843,9 +840,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define MIDI_RX_SIZE_480      512
   #define AUDIO_INTERFACE	3	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     5
-  #define AUDIO_TX_SIZE         180
   #define AUDIO_RX_ENDPOINT     5
-  #define AUDIO_RX_SIZE         180
   #define AUDIO_SYNC_ENDPOINT	6
   #define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_UNUSED + ENDPOINT_TRANSMIT_INTERRUPT
   #define ENDPOINT3_CONFIG	ENDPOINT_RECEIVE_BULK + ENDPOINT_TRANSMIT_BULK
@@ -925,9 +920,7 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
   #define KEYMEDIA_INTERVAL     4
   #define AUDIO_INTERFACE	9	// Audio (uses 3 consecutive interfaces)
   #define AUDIO_TX_ENDPOINT     13
-  #define AUDIO_TX_SIZE         180
   #define AUDIO_RX_ENDPOINT     13
-  #define AUDIO_RX_SIZE         180
   #define AUDIO_SYNC_ENDPOINT	14
   #define MULTITOUCH_INTERFACE  12	// Touchscreen
   #define MULTITOUCH_ENDPOINT   15


### PR DESCRIPTION
Update USB descriptors to have variable number of channels on TX and RX

Added support for defining multiple data pins.  This allows use of more than one TX and/or RX pin.

Allow for choosing different USB sample rates